### PR TITLE
Upgrade to Twig 3

### DIFF
--- a/__tests__/twig-extensions/alter-twig.php
+++ b/__tests__/twig-extensions/alter-twig.php
@@ -1,7 +1,7 @@
 <?php
 
-function addCustomExtension(\Twig_Environment &$env, $config) {
-  $env->addFunction(new \Twig_SimpleFunction('customTwigFunctionThatSaysWorld', function () {
+function addCustomExtension(\Twig\Environment &$env, $config) {
+  $env->addFunction(new \Twig\TwigFunction('customTwigFunctionThatSaysWorld', function () {
     return 'Custom World';
   }));
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require": {
     "ext-json": "*",
-    "twig/twig": "^2.12",
+    "twig/twig": "^3.0",
     "react/http": "^0.8.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e7695ac4ac0be2f471e853a31c12c38",
+    "content-hash": "1baf75ac18bf4eb757a971a4dc73cb57",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -699,37 +699,34 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.12.5",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94"
+                "reference": "f795ca686d38530045859b0350b5352f7d63447d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/18772e0190734944277ee97a02a9a6c6555fcd94",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f795ca686d38530045859b0350b5352f7d63447d",
+                "reference": "f795ca686d38530045859b0350b5352f7d63447d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0"
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.12-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -760,7 +757,21 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2020-02-11T15:31:23+00:00"
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-05T15:40:36+00:00"
         }
     ],
     "packages-dev": [],
@@ -772,5 +783,6 @@
     "platform": {
         "ext-json": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -107,7 +107,7 @@ class TwigRenderer {
         'message' => '',
       ];
     } catch (\Exception $exception) {
-      $message = 'Error trying to render "' . $templatePath . '". ' . $exception->getMessage();
+      $message = 'Error trying to render "' . $templatePath . '". ' . $exception->getMessage() . ' at ' . $exception->getFile() . ':' . $exception->getLine();;
       $response = [
         'ok' => false,
         'message' => $message,

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -4,17 +4,17 @@ namespace BasaltInc\TwigRenderer;
 
 class TwigRenderer {
   /**
-   * @var $twig \Twig_Environment
+   * @var $twig \Twig\Environment
    */
   private $twig;
 
   /**
-   * @var $loader \Twig_Loader_Filesystem
+   * @var $loader \Twig\Loader\FilesystemLoader
    */
   private $loader;
 
   /**
-   * @var $loaders \Twig_Loader_Chain
+   * @var $loaders \Twig\Loader\ChainLoader
    */
   private $loaders;
 
@@ -29,7 +29,7 @@ class TwigRenderer {
     if (isset($this->config['relativeFrom'])) {
       $rootPath = $this->config['relativeFrom'];
     }
-    $this->loader = new \Twig_Loader_Filesystem($this->config['src']['roots'], $rootPath);
+    $this->loader = new \Twig\Loader\FilesystemLoader($this->config['src']['roots'], $rootPath);
 
     if (isset($this->config['src']['namespaces'])) {
       foreach ($this->config['src']['namespaces'] as $namespace) {
@@ -39,7 +39,7 @@ class TwigRenderer {
       }
     }
 
-    $this->loaders = new \Twig_Loader_Chain([
+    $this->loaders = new \Twig\Loader\ChainLoader([
       $this->loader,
     ]);
 
@@ -47,7 +47,7 @@ class TwigRenderer {
   }
 
   private function createTwigEnv($loaders) {
-    $twig = new \Twig_Environment($loaders, [
+    $twig = new \Twig\Environment($loaders, [
       'debug' => $this->config['debug'],
       'autoescape' => $this->config['autoescape'],
       'cache' => false, // @todo Implement Twig caching
@@ -68,11 +68,11 @@ class TwigRenderer {
 
   public function renderString($templateString, $data = []) {
     $templateName = 'StringRenderer'; // @todo ensure this simple name is ok; should be!
-    $loader = new \Twig_Loader_Array([
+    $loader = new \Twig\Loader\ArrayLoader([
       $templateName => $templateString,
     ]);
 
-    $loaders = new \Twig_Loader_Chain([
+    $loaders = new \Twig\Loader\ChainLoader([
       $loader,
       $this->loader,
     ]);
@@ -121,7 +121,7 @@ class TwigRenderer {
   }
 
   /**
-   * @return \Twig_Environment
+   * @return \Twig\Environment
    */
   public function getTwig() {
     return $this->twig;


### PR DESCRIPTION
This is an upgrade to Twig 3. The only thing to change was to change to the namespaces classes instead of  `PSR-0`  classes. Please note that I didn't test yet in a real project, but the tests passes tough.