### PR TITLE
Fix autoescaping for Twig 2.x

### DIFF
--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -49,7 +49,7 @@ class TwigRenderer {
   private function createTwigEnv($loaders) {
     $twig = new \Twig_Environment($loaders, [
       'debug' => $this->config['debug'],
-      'autoescape' => $this->config['autoescape'],
+      'autoescape' => $this->config['autoescape'] ? 'html' : false,
       'cache' => false, // @todo Implement Twig caching
     ]);
 


### PR DESCRIPTION
Twig 1 and 2 both have an autoescape constructor parameter. In 1.x passing false was the same as passing 'html'. In 2.x you must explicitly pass 'html'.

See
- https://github.com/twigphp/Twig/blob/0887422319889e442458e48e2f3d9add1a172ad5/src/Environment.php#L111
- https://github.com/twigphp/Twig/blob/872646a70ff83b3628d50c9bafa117af9f1da59e/src/Environment.php#L92

Closes #102.